### PR TITLE
update the dependent version of timely-dataflow.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
 
 [dependencies]
-timely = { git = "https://github.com/frankmcsherry/timely-dataflow" }
+timely="0.7.0"
 
 [dependencies.graph_map]
 git="http://github.com/frankmcsherry/graph-map"

--- a/static_graph/Cargo.toml
+++ b/static_graph/Cargo.toml
@@ -4,10 +4,8 @@ name = "dataflow-join"
 version = "0.0.1"
 authors = ["Frank McSherry <fmcsherry@me.com>"]
 
-[dependencies.timely]
-git="https://github.com/frankmcsherry/timely-dataflow"
-
 [dependencies]
+timely="0.7.0"
 core_affinity = "0.5.9"
 timely_sort="0.1.1"
 time = "*"


### PR DESCRIPTION
Some operations are not supported in the newest timely-dataflow and can lead to compile error, such as input_graph.advance_to(prev_time.inner + 1)(examples/motif.rs:107) and timely::progress::timestamp::RootTimestamp;(examples/triangles.rs:14). 
So the dependency of timely-dataflow should be changed into an older version.